### PR TITLE
Updated filterdb for Avisynth 3.7.1 Beta 20

### DIFF
--- a/filterdb.dat
+++ b/filterdb.dat
@@ -510,7 +510,7 @@ clip
 
 ConvertToRGB(
 clip,
-string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "AVERAGE"),
+string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "Rec2020" / "PC.2020" / "AVERAGE"),
 bool "interlaced"=false,
 [string "ChromaInPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV")],
 [string "chromaresample"="bicubic" ("point"/ "bilinear"/ "bicubic"/ "lanczos"/ "lanczos4"/ "blackman"/ "spline16"/ "spline36"/ "spline64"/ "gauss"/ "sinc")]
@@ -518,7 +518,7 @@ bool "interlaced"=false,
 
 ConvertToRGB24(
 clip,
-string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "AVERAGE"),
+string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "Rec2020" / "PC.2020" / "AVERAGE"),
 bool "interlaced"=false,
 [string "ChromaInPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV")],
 [string "chromaresample"="bicubic" ("point"/ "bilinear"/ "bicubic"/ "lanczos"/ "lanczos4"/ "blackman"/ "spline16"/ "spline36"/ "spline64"/ "gauss"/ "sinc")]
@@ -526,7 +526,7 @@ bool "interlaced"=false,
 
 ConvertToRGB32(
 clip,
-string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "AVERAGE"),
+string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "Rec2020" / "PC.2020" / "AVERAGE"),
 bool "interlaced"=false,
 [string "ChromaInPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV")],
 [string "chromaresample"="bicubic" ("point"/ "bilinear"/ "bicubic"/ "lanczos"/ "lanczos4"/ "blackman"/ "spline16"/ "spline36"/ "spline64"/ "gauss"/ "sinc")]
@@ -534,7 +534,7 @@ bool "interlaced"=false,
 
 ConvertToY8(
 clip,
-string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "AVERAGE")
+string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "Rec2020" / "PC.2020" / "AVERAGE")
 )
 
 ConvertToYUY2(
@@ -547,16 +547,16 @@ bool "interlaced"=false,
 
 ConvertToYV12(
 clip,
-string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "AVERAGE"),
+string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "Rec2020" / "PC.2020" / "AVERAGE"),
 bool "interlaced"=false,
-[string "ChromaInPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV")],
+[string "ChromaInPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV" / "top_left")],
 [string "chromaresample"="bicubic" ("point"/ "bilinear"/ "bicubic"/ "lanczos"/ "lanczos4"/ "blackman"/ "spline16"/ "spline36"/ "spline64"/ "gauss"/ "sinc")],
-[string "ChromaOutPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV")]
+[string "ChromaOutPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV" / "top_left")]
 )
 
 ConvertToYV16(
 clip,
-string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "AVERAGE"),
+string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "Rec2020" / "PC.2020" / "AVERAGE"),
 bool "interlaced"=false,
 [string "ChromaInPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV")],
 [string "chromaresample"="bicubic" ("point"/ "bilinear"/ "bicubic"/ "lanczos"/ "lanczos4"/ "blackman"/ "spline16"/ "spline36"/ "spline64"/ "gauss"/ "sinc")]
@@ -564,7 +564,7 @@ bool "interlaced"=false,
 
 ConvertToYV24(
 clip,
-string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "AVERAGE"),
+string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "Rec2020" / "PC.2020" / "AVERAGE"),
 bool "interlaced"=false,
 [string "ChromaInPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV")],
 [string "chromaresample"="bicubic" ("point"/ "bilinear"/ "bicubic"/ "lanczos"/ "lanczos4"/ "blackman"/ "spline16"/ "spline36"/ "spline64"/ "gauss"/ "sinc")]
@@ -572,7 +572,7 @@ bool "interlaced"=false,
 
 ConvertToYV411(
 clip,
-string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "AVERAGE"),
+string "matrix"="Rec709" ("Rec601"/ "PC.601"/ "Rec709"/ "PC.709"/ "Rec2020" / "PC.2020" / "AVERAGE"),
 bool "interlaced"=false,
 [string "ChromaInPlacement"="MPEG2" ("MPEG2"/ "MPEG1"/ "DV")],
 [string "chromaresample"="bicubic" ("point"/ "bilinear"/ "bicubic"/ "lanczos"/ "lanczos4"/ "blackman"/ "spline16"/ "spline36"/ "spline64"/ "gauss"/ "sinc")]


### PR DESCRIPTION
Added new Chroma In Placement and Chroma Out Placement for yv12 (top_left) and new color matrices (Rec2020 and PC.2020) for Converttoyv12, Converttoyv16, Converttoyv24, ConverttoYV411, ConverttoY8, ConverttoRGB32, ConverttoRGB24, ConverttoRGB, ConverttoYUV420, ConverttoYUV422, ConverttoYUV444